### PR TITLE
Alarm Vacation Mode - Update test configuration.

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -163,6 +163,10 @@ class AlarmControlPanelEntity(Entity):
         """Send arm vacation command."""
         raise NotImplementedError()
 
+    async def async_alarm_arm_vacation(self, code=None):
+        """Send arm vacation command."""
+        await self.hass.async_add_executor_job(self.alarm_arm_vacation, code)
+
     def alarm_trigger(self, code=None):
         """Send alarm trigger command."""
         raise NotImplementedError()

--- a/tests/components/alarm_control_panel/common.py
+++ b/tests/components/alarm_control_panel/common.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     SERVICE_ALARM_ARM_CUSTOM_BYPASS,
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_ARM_NIGHT,
+    SERVICE_ALARM_ARM_VACATION,
     SERVICE_ALARM_DISARM,
     SERVICE_ALARM_TRIGGER,
 )
@@ -59,6 +60,19 @@ async def async_alarm_arm_night(hass, code=None, entity_id=ENTITY_MATCH_ALL):
         data[ATTR_ENTITY_ID] = entity_id
 
     await hass.services.async_call(DOMAIN, SERVICE_ALARM_ARM_NIGHT, data, blocking=True)
+
+
+async def async_alarm_arm_vacation(hass, code=None, entity_id=ENTITY_MATCH_ALL):
+    """Send the alarm the command for disarm."""
+    data = {}
+    if code:
+        data[ATTR_CODE] = code
+    if entity_id:
+        data[ATTR_ENTITY_ID] = entity_id
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_ALARM_ARM_VACATION, data, blocking=True
+    )
 
 
 async def async_alarm_trigger(hass, code=None, entity_id=ENTITY_MATCH_ALL):

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -154,7 +154,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
         "trigger": {"extra_fields": []},
     }
     actions = await async_get_device_automations(hass, "action", device_entry.id)
-    assert len(actions) == 5
+    assert len(actions) == 6
     for action in actions:
         capabilities = await async_get_device_automation_capabilities(
             hass, "action", action
@@ -201,7 +201,7 @@ async def test_get_action_capabilities_arm_code(hass, device_reg, entity_reg):
         "trigger": {"extra_fields": []},
     }
     actions = await async_get_device_automations(hass, "action", device_entry.id)
-    assert len(actions) == 5
+    assert len(actions) == 6
     for action in actions:
         capabilities = await async_get_device_automation_capabilities(
             hass, "action", action

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -185,7 +185,7 @@ async def test_websocket_get_action_capabilities(
         "alarm_control_panel", "test", "5678", device_id=device_entry.id
     )
     hass.states.async_set(
-        "alarm_control_panel.test_5678", "attributes", {"supported_features": 15}
+        "alarm_control_panel.test_5678", "attributes", {"supported_features": 47}
     )
     expected_capabilities = {
         "arm_away": {"extra_fields": []},
@@ -210,7 +210,7 @@ async def test_websocket_get_action_capabilities(
     actions = msg["result"]
 
     id = 2
-    assert len(actions) == 5
+    assert len(actions) == 6
     for action in actions:
         await client.send_json(
             {

--- a/tests/testing_config/custom_components/test/alarm_control_panel.py
+++ b/tests/testing_config/custom_components/test/alarm_control_panel.py
@@ -8,12 +8,14 @@ from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
     SUPPORT_ALARM_ARM_HOME,
     SUPPORT_ALARM_ARM_NIGHT,
+    SUPPORT_ALARM_ARM_VACATION,
     SUPPORT_ALARM_TRIGGER,
 )
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_VACATION,
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
 )
@@ -79,6 +81,7 @@ class MockAlarm(MockEntity, AlarmControlPanelEntity):
             | SUPPORT_ALARM_ARM_AWAY
             | SUPPORT_ALARM_ARM_NIGHT
             | SUPPORT_ALARM_TRIGGER
+            | SUPPORT_ALARM_ARM_VACATION
         )
 
     def alarm_arm_away(self, code=None):
@@ -94,6 +97,11 @@ class MockAlarm(MockEntity, AlarmControlPanelEntity):
     def alarm_arm_night(self, code=None):
         """Send arm night command."""
         self._state = STATE_ALARM_ARMED_NIGHT
+        self.async_write_ha_state()
+
+    def alarm_arm_vacation(self, code=None):
+        """Send arm night command."""
+        self._state = STATE_ALARM_ARMED_VACATION
         self.async_write_ha_state()
 
     def alarm_disarm(self, code=None):


### PR DESCRIPTION
Hi @posixx 

I saw your PR in the HA repo and thought I would have a look at why your tests where failing.

I found the root cause being the test configuration use by the HA team needed changing along with some updates to test results.

If you merge this in the tests should pass for the Home Assistant PR